### PR TITLE
[test][_testConfig] take process.env.HOST and process.env.MASTER_KEY

### DIFF
--- a/test/_testConfig.js
+++ b/test/_testConfig.js
@@ -1,5 +1,5 @@
 var masterKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 var host = "https://localhost:443";
 
-exports.host = host;
-exports.masterKey = masterKey;
+exports.host = process.env.HOST || host;
+exports.masterKey = process.env.MASTER_KEY || masterKey;


### PR DESCRIPTION
easier for testing without accidentally commit private keys
