### PR TITLE
Properly handle dashes in the mediaIds

### DIFF
--- a/source/lib/base.js
+++ b/source/lib/base.js
@@ -297,11 +297,13 @@ var Base = {
 
      /** @ignore */
     getAttachmentIdFromMediaId: function(mediaId) {
-        var buffer = new Buffer(mediaId, "base64");
+        // Replace - with / on the incoming mediaId.  This will preserve the / so that we can revert it later.
+        var buffer = new Buffer(mediaId.replace("-", "/"), "base64");
         var ResoureIdLength = 20;
         var attachmentId = "";
         if (buffer.length > ResoureIdLength) {
-            attachmentId = buffer.toString("base64", 0, ResoureIdLength);
+            // After the base64 conversion, change the / back to a - to get the proper attachmentId
+            attachmentId = buffer.toString("base64", 0, ResoureIdLength).replace("/", "-");
         } else {
             attachmentId = mediaId;
         }

--- a/source/lib/base.js
+++ b/source/lib/base.js
@@ -298,12 +298,12 @@ var Base = {
      /** @ignore */
     getAttachmentIdFromMediaId: function(mediaId) {
         // Replace - with / on the incoming mediaId.  This will preserve the / so that we can revert it later.
-        var buffer = new Buffer(mediaId.replace("-", "/"), "base64");
+        var buffer = new Buffer(mediaId.replace(/-/g, "/"), "base64");
         var ResoureIdLength = 20;
         var attachmentId = "";
         if (buffer.length > ResoureIdLength) {
             // After the base64 conversion, change the / back to a - to get the proper attachmentId
-            attachmentId = buffer.toString("base64", 0, ResoureIdLength).replace("/", "-");
+            attachmentId = buffer.toString("base64", 0, ResoureIdLength).replace(/\//g, "-");
         } else {
             attachmentId = mediaId;
         }

--- a/source/test/baseTests.js
+++ b/source/test/baseTests.js
@@ -129,3 +129,30 @@ describe("Base._isValidCollectionLink", function () {
         });
     });
 });
+
+describe("Base.getAttachmentIdFromMediaId", function () {
+    var test = function (input, expected) {
+        assert.strictEqual(Base.getAttachmentIdFromMediaId(input), expected);
+    };
+
+    it("Alpha-numeric only:  6hl2ALdWbQCxAgAAAAAAAC4b1VoB => 6hl2ALdWbQCxAgAAAAAAAC4b1Vo=", function () {
+        test("6hl2ALdWbQCxAgAAAAAAAC4-1VoB", "6hl2ALdWbQCxAgAAAAAAAC4-1Vo=");
+    });
+
+    it("Single hyphen (-):  6hl2ALdWbQCxAgAAAAAAAC4-1VoB => 6hl2ALdWbQCxAgAAAAAAAC4-1Vo=", function () {
+        test("6hl2ALdWbQCxAgAAAAAAAC4-1VoB", "6hl2ALdWbQCxAgAAAAAAAC4-1Vo=");
+    });
+
+    it("Multiple hyphens (-):  6hl2ALdWb-CxAgAAAAAAAC4-1VoB => 6hl2ALdWb-CxAgAAAAAAAC4-1Vo=", function () {
+        test("6hl2ALdWb-CxAgAAAAAAAC4-1VoB", "6hl2ALdWb-CxAgAAAAAAAC4-1Vo=");
+    });
+
+    it("Plus sign (+):  6hl2ALdWb+CxAgAAAAAAAC4Q1VoB => 6hl2ALdWb+CxAgAAAAAAAC4Q1Vo=", function () {
+        test("6hl2ALdWb-CxAgAAAAAAAC4-1VoB", "6hl2ALdWb-CxAgAAAAAAAC4-1Vo=");
+    });
+
+    it("Plus sign (+), Hyphen (-):  6hl2ALdWb+CxAgAAAAAAAC4-1VoB => 6hl2ALdWb+CxAgAAAAAAAC4-1Vo=", function () {
+        test("6hl2ALdWb-CxAgAAAAAAAC4-1VoB", "6hl2ALdWb-CxAgAAAAAAAC4-1Vo=");
+    });
+
+});

--- a/source/test/baseTests.js
+++ b/source/test/baseTests.js
@@ -135,24 +135,28 @@ describe("Base.getAttachmentIdFromMediaId", function () {
         assert.strictEqual(Base.getAttachmentIdFromMediaId(input), expected);
     };
 
-    it("Alpha-numeric only:  6hl2ALdWbQCxAgAAAAAAAC4b1VoB => 6hl2ALdWbQCxAgAAAAAAAC4b1Vo=", function () {
+    it("> 20 characters, Alpha-numeric only:  6hl2ALdWbQCxAgAAAAAAAC4b1VoB => 6hl2ALdWbQCxAgAAAAAAAC4b1Vo=", function () {
         test("6hl2ALdWbQCxAgAAAAAAAC4-1VoB", "6hl2ALdWbQCxAgAAAAAAAC4-1Vo=");
     });
 
-    it("Single hyphen (-):  6hl2ALdWbQCxAgAAAAAAAC4-1VoB => 6hl2ALdWbQCxAgAAAAAAAC4-1Vo=", function () {
+    it("> 20 characters, Single hyphen (-):  6hl2ALdWbQCxAgAAAAAAAC4-1VoB => 6hl2ALdWbQCxAgAAAAAAAC4-1Vo=", function () {
         test("6hl2ALdWbQCxAgAAAAAAAC4-1VoB", "6hl2ALdWbQCxAgAAAAAAAC4-1Vo=");
     });
 
-    it("Multiple hyphens (-):  6hl2ALdWb-CxAgAAAAAAAC4-1VoB => 6hl2ALdWb-CxAgAAAAAAAC4-1Vo=", function () {
+    it("> 20 characters, Multiple hyphens (-):  6hl2ALdWb-CxAgAAAAAAAC4-1VoB => 6hl2ALdWb-CxAgAAAAAAAC4-1Vo=", function () {
         test("6hl2ALdWb-CxAgAAAAAAAC4-1VoB", "6hl2ALdWb-CxAgAAAAAAAC4-1Vo=");
     });
 
-    it("Plus sign (+):  6hl2ALdWb+CxAgAAAAAAAC4Q1VoB => 6hl2ALdWb+CxAgAAAAAAAC4Q1Vo=", function () {
+    it("> 20 characters, Plus sign (+):  6hl2ALdWb+CxAgAAAAAAAC4Q1VoB => 6hl2ALdWb+CxAgAAAAAAAC4Q1Vo=", function () {
         test("6hl2ALdWb-CxAgAAAAAAAC4-1VoB", "6hl2ALdWb-CxAgAAAAAAAC4-1Vo=");
     });
 
-    it("Plus sign (+), Hyphen (-):  6hl2ALdWb+CxAgAAAAAAAC4-1VoB => 6hl2ALdWb+CxAgAAAAAAAC4-1Vo=", function () {
+    it("> 20 characters, Plus sign (+), Hyphen (-):  6hl2ALdWb+CxAgAAAAAAAC4-1VoB => 6hl2ALdWb+CxAgAAAAAAAC4-1Vo=", function () {
         test("6hl2ALdWb-CxAgAAAAAAAC4-1VoB", "6hl2ALdWb-CxAgAAAAAAAC4-1Vo=");
+    });
+
+    it("< 20 characters, Plus sign (+), Hyphen (-):  6hl2A-dWb+CxAgAAAA => 6hl2A-dWb+CxAgAAAA", function () {
+        test("6hl2A-dWb+CxAgAAAA", "6hl2A-dWb+CxAgAAAA");
     });
 
 });


### PR DESCRIPTION
This is a fix for https://github.com/Azure/azure-documentdb-node/issues/81 in which a dash (-) was being converted to a plus (+) in the base64 conversion and the resulting attachmentId would be incorrect