### PR TITLE
Proxy support

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -33,5 +33,8 @@
       "type": "Apache License, Version 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
-  ]
+  ],
+  "dependencies": {
+    "tunnel": "0.0.4"
+  }
 }


### PR DESCRIPTION
I hacked together rudimentary proxy support in this PR. This was requested in [Proxy Support #116](https://github.com/Azure/azure-documentdb-node/issues/116).

A couple quick points:
- This PR takes a dependency on [tunnel](https://github.com/koichik/node-tunnel).
- The proxy support only kicks in when process.env.http_proxy or process.env.https_proxy is set. I didn't want to modify any documented API, since I don't know your team's preferences :)
