### PR TITLE
fixes PipelinedExecutionContext is not defined

### DIFF
--- a/source/lib/queryExecutionContext/pipelinedQueryExecutionContext.js
+++ b/source/lib/queryExecutionContext/pipelinedQueryExecutionContext.js
@@ -32,8 +32,8 @@ var Base = require("../base")
 //SCRIPT START
 var PipelinedQueryExecutionContext = Base.defineClass(
     /**
-     * Provides the PipelinedExecutionContext. It piplelines top and orderby execution context if necessary
-     * @constructor PipelinedExecutionContext
+     * Provides the PipelinedQueryExecutionContext. It piplelines top and orderby execution context if necessary
+     * @constructor PipelinedQueryExecutionContext
      * @param {DocumentClient} documentclient        - The service endpoint to use to create the client.
      * @param {FeedOptions} [options]                - Represents the feed options.
      * @param {object} partitionedQueryExecutionInfo  - PartitionedQueryExecutionInfo
@@ -46,7 +46,7 @@ var PipelinedQueryExecutionContext = Base.defineClass(
         this.endpoint = executionContext;
         this.pageSize = options["maxItemCount"];
         if (this.pageSize === undefined) {
-            this.pageSize = PipelinedExecutionContext.DEFAULT_PAGE_SIZE;
+            this.pageSize = PipelinedQueryExecutionContext.DEFAULT_PAGE_SIZE;
         }
         var orderBy = QueryExecutionInfoParser.parseOrderBy(partitionedQueryExecutionInfo);
         if (Array.isArray(orderBy) && orderBy.length > 0) {


### PR DESCRIPTION
Enabling cross partition queries without passing `maxItemCount` throws the following error:

```javascript
/documentdb/node_modules/documentdb/lib/queryExecutionContext/pipelinedQueryExecutionContext.js:49
            this.pageSize = PipelinedExecutionContext.DEFAULT_PAGE_SIZE;
                            ^

ReferenceError: PipelinedExecutionContext is not defined
    at new <anonymous> (/documentdb/node_modules/documentdb/lib/queryExecutionContext/pipelinedQueryExecutionContext.js:49:29)
    at _createPipelinedExecutionContext (/documentdb/node_modules/documentdb/lib/queryExecutionContext/proxyQueryExecutionContext.js:98:20)
    at /documentdb/node_modules/documentdb/lib/queryExecutionContext/proxyQueryExecutionContext.js:70:59
    at /documentdb/node_modules/documentdb/lib/queryExecutionContext/defaultQueryExecutionContext.js:62:17
    at /documentdb/node_modules/documentdb/lib/queryExecutionContext/defaultQueryExecutionContext.js:81:32
    at /documentdb/node_modules/documentdb/lib/queryExecutionContext/defaultQueryExecutionContext.js:124:28
    at successCallback (/documentdb/node_modules/documentdb/lib/documentclient.js:2284:33)
    at /documentdb/node_modules/documentdb/lib/retryUtility.js:90:20
    at IncomingMessage.<anonymous> (/documentdb/node_modules/documentdb/lib/request.js:68:24)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
This PR fixes the typo