### PR TITLE
Return headers for all query requests

### DIFF
--- a/source/lib/queryExecutionContext/documentProducer.js
+++ b/source/lib/queryExecutionContext/documentProducer.js
@@ -94,9 +94,9 @@ var DocumentProducer = Base.defineClass(
         */
         nextItem: function (callback) {
             var that = this;
-            this.internalExecutionContext.nextItem(function (err, item) {
+            this.internalExecutionContext.nextItem(function (err, item, headers) {
                 that.bufferedCurrentItem = undefined;
-                callback(err, item);
+                callback(err, item, headers);
             });
         },
 
@@ -108,10 +108,10 @@ var DocumentProducer = Base.defineClass(
          */
         current: function (callback) {
             var that = this;
-            this.internalExecutionContext.current(function (err, item) {
+            this.internalExecutionContext.current(function (err, item, headers) {
                 // sets the buffered current item for non async access
                 that.bufferedCurrentItem = item;
-                callback(err, item);
+                callback(err, item, headers);
             });
         },
     },

--- a/source/lib/queryExecutionContext/endpointComponent.js
+++ b/source/lib/queryExecutionContext/endpointComponent.js
@@ -45,14 +45,14 @@ var OrderByEndpointComponent = Base.defineClass(
          * @param {callback} callback - Function to execute for each element. the function takes two parameters error, element.
          */
         nextItem: function (callback) {
-            this.executionContext.nextItem(function (err, item) {
+            this.executionContext.nextItem(function (err, item, headers) {
                 if (err) {
                     return callback(err, undefined);
                 }
                 if (item === undefined) {
                     return callback(undefined, undefined);
                 }
-                callback(undefined, item["payload"]);
+                callback(undefined, item["payload"], headers);
             });
         },
 
@@ -110,8 +110,8 @@ var TopEndpointComponent = Base.defineClass(
                 return callback(undefined, undefined);
             }
             this.topCount--;
-            this.executionContext.nextItem(function (err, item) {
-                callback(err, item);
+            this.executionContext.nextItem(function (err, item, headers) {
+                callback(err, item, headers);
             });
         },
 

--- a/source/lib/queryIterator.js
+++ b/source/lib/queryIterator.js
@@ -104,6 +104,7 @@ var QueryIterator = Base.defineClass(
         toArray: function (callback) {
             this.reset();
             this.toArrayTempResources = [];
+            this.toArrayTempHeaders = [];
             this._toArrayImplementation(callback);
         },
 
@@ -141,16 +142,17 @@ var QueryIterator = Base.defineClass(
                 if (err) {
                     return callback(err, undefined, headers);
                 }
-                // concatinate the results and fetch more
-                that.toArrayLastResHeaders = headers;
 
                 if (resource === undefined) {
-                
                     // no more results
-                    return callback(undefined, that.toArrayTempResources, that.toArrayLastResHeaders);
-                } 
+                    return callback(undefined, that.toArrayTempResources, that.toArrayTempHeaders);
+                }
 
+                // concatinate the results and fetch more
                 that.toArrayTempResources = that.toArrayTempResources.concat(resource);
+                if(headers) {
+                    that.toArrayTempHeaders = that.toArrayTempHeaders.concat(headers);
+                }
                 that._toArrayImplementation(callback);
             });
         },


### PR DESCRIPTION
The aim for this PR is to return an array of all the headers returned from docDb for the current request. It could be that it would be better to extract information, such as the sum of the request charge, but I first wanted to check if I'm on the right track.

There are a couple of requests which isn't tracked in this version, such as the request for partitions and the query-rewrite responses from the server, but as far as I understand it there's no request charge for these requests?

This is a new code-base for me so I could be missing some changes to some of the other execution contexts? So far I only checked that it worked in my particular use-case which is a cross-partition query.

This PR is for Issue #146.