### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Microsoft Azure DocumentDB Node.js SDK
+# Microsoft Azure DocumentDB Node.js SDK
 
 ![](https://img.shields.io/npm/v/documentdb.svg)
 ![](https://img.shields.io/npm/dm/documentdb.svg)
@@ -8,25 +8,25 @@ This project provides a node module that makes it easy to interact with Azure Do
 
 For documentation please see the Microsoft Azure [Node.js Developer Center](http://azure.microsoft.com/en-us/develop/nodejs/) and the [Microsoft Azure DocumentDB Node.js SDK Documentation](http://azure.github.io/azure-documentdb-node/).
 
-##Installation
-###Core Module
+## Installation
+### Core Module
 
 The core module uses the callbacks model for responses, exposed through the DocumentClient 
 
     npm install documentdb
 
 
-##Usage
+## Usage
 
 To use this SDK to call Azure DocumentDB, you need to first [create an account](http://azure.microsoft.com/en-us/documentation/articles/documentdb-create-account/).
 
 You can follow this [tutorial](http://azure.microsoft.com/en-us/documentation/articles/documentdb-nodejs-application/) to help you get started.
 
-####Note:
+#### Note:
 When connecting to the [emulator](https://docs.microsoft.com/en-us/azure/documentdb/documentdb-nosql-local-emulator) from the SDK, SSL verification is disabled. 
 
-##Examples
-###Hello World using Callbacks via the Core Module
+## Examples
+### Hello World using Callbacks via the Core Module
 
 ```js
 var DocumentClient = require('documentdb').DocumentClient;
@@ -63,23 +63,23 @@ function cleanup(client, database) {
 }
 ```
 
-###Youtube Videos
+### Youtube Videos
 
 Getting started with Azure DocumentDB on Node.js:
 
 [![Azure Demo: Getting started with Azure DocumentDB on Node.js](http://img.youtube.com/vi/UAE7h9PCZjA/0.jpg)](http://www.youtube.com/watch?v=UAE7h9PCZjA)
 
-##Need Help?
+## Need Help?
 
 Be sure to check out the Microsoft Azure [Developer Forums on MSDN](https://social.msdn.microsoft.com/forums/azure/en-US/home?forum=AzureDocumentDB) or the [Developer Forums on Stack Overflow](http://stackoverflow.com/questions/tagged/azure-documentdb) if you have trouble with the provided code.
 
-##Contribute Code or Provide Feedback
+## Contribute Code or Provide Feedback
 
 If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines.html).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-documentdb-node/issues) section of the project.
 
-##Learn More
+## Learn More
 
 * [Azure Developer Center](http://azure.microsoft.com/en-us/develop/nodejs)
 * [Azure DocumentDB Node.js SDK Documentation](http://azure.github.io/azure-documentdb-node/)

--- a/samples/readme.md
+++ b/samples/readme.md
@@ -1,7 +1,7 @@
-##Introduction ##
+## Introduction  ##
 These samples demonstrate how to use the Node.js SDK to interact with the [Azure DocumentDB](http://azure.microsoft.com/services/documentdb)  service
 
-##Building the sample ##
+## Building the sample  ##
 
 These samples were built using the [Node.js Tools for Visual Studio](https://github.com/Microsoft/nodejstools) and include *njsproj files accordingly. However, you do not *need* Visual Studio to run these samples. Just ignore the nsjprof files if you wish, and open the app.js in your choice of editor such as [Visual Studio Code](https://code.visualstudio.com/), or even a text editor such [Sublime](http://www.sublimetext.com/). The choice is yours!
 
@@ -10,7 +10,7 @@ So head over to [How to create a DocumentDB database account](https://azure.micr
 
 Once you have your DocumentDB account setup, you can run these files using Visual Studio if you are using it, or by simply running **node app.js**
 
-##Description ##
+## Description  ##
 
 Azure DocumentDB is a fully managed, scalable, query-able, schema free JSON document database service built for modern applications and delivered to you by Microsoft.
 
@@ -32,6 +32,6 @@ After walking through these samples you should have a good idea of how to get go
 
 There are step-by-step tutorials and more documentation on the [DocumentDB documentation](http://azure.microsoft.com/en-us/documentation/services/documentdb/) page so head over about this NoSQL document database.
  
-##More information ##
+## More information  ##
 
 For more information on this database service, please refer to the [Azure DocumentDB](http://azure.microsoft.com/services/documentdb) service page.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
