### PR TITLE
Cannot find module './SessionContainer' fix

### DIFF
--- a/source/lib/documentclient.js
+++ b/source/lib/documentclient.js
@@ -33,7 +33,7 @@ var Base = require("./base")
     , Helper = require("./helper").Helper
     , util = require("util")
     , Platform = require("./platform")
-    , SessionContainer = require("./SessionContainer");
+    , SessionContainer = require("./sessionContainer");
 
 //SCRIPT START
 var DocumentClient = Base.defineClass(


### PR DESCRIPTION
Filename is `sessionContainer`, so we should require `sessionContainer`, but not `SessionContainer`.
Requiring `SessionContainer` results in `Error: Cannot find module './SessionContainer'` (tested on linux)