### PR TITLE
Add http/https ProxyUrl setting in ConnectionPolicy

### DIFF
--- a/source/lib/documents.js
+++ b/source/lib/documents.js
@@ -280,6 +280,7 @@ var AzureDocuments = Base.defineClass(null, null,
          * @property {RetryOptions} RetryOptions           - RetryOptions instance which defines several configurable properties used during retry.
          * @property {bool} DisableSSLVerification         - Flag to disable SSL verification for the requests. SSL verification is enabled by default. Don't set this when targeting production endpoints.
          *                                                   This is intended to be used only when targeting emulator endpoint to avoid failing your requests with SSL related error.
+         * @property {string} ProxyUrl                     - Http/Https proxy url
         */
         ConnectionPolicy: Base.defineClass(function() {
             Object.defineProperty(this, "_defaultRequestTimeout", {
@@ -305,6 +306,7 @@ var AzureDocuments = Base.defineClass(null, null,
             this.PreferredLocations = [];
             this.RetryOptions = new RetryOptions();
             this.DisableSSLVerification = false;
+            this.ProxyUrl = "";
         })
     }
 );

--- a/source/lib/request.js
+++ b/source/lib/request.js
@@ -29,7 +29,9 @@ var Documents = require("./documents")
     , tunnel = require("tunnel")
     , url = require("url")
     , querystring = require("querystring")
-    , RetryUtility = require("./retryUtility");
+    , RetryUtility = require("./retryUtility")
+    // Dedicated Agent for socket pooling
+    , keepAliveAgent = createRequestAgent();
 
 //----------------------------------------------------------------------------
 // Utility methods
@@ -213,7 +215,7 @@ var RequestHandler = {
         requestOptions.method = method;
         requestOptions.path = path;
         requestOptions.headers = headers;
-        requestOptions.agent = createRequestAgent();
+        requestOptions.agent = keepAliveAgent;
         requestOptions.secureProtocol = "TLSv1_client_method";
 
         if (connectionPolicy.DisableSSLVerification === true) {

--- a/source/package.json
+++ b/source/package.json
@@ -36,7 +36,8 @@
     "binary-search-bounds": "2.0.3",
     "priorityqueuejs": "1.0.0",
     "semaphore": "1.0.5",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "tunnel": "~0.0.5"
   },
   "repository": {
     "type": "git",

--- a/source/package.json
+++ b/source/package.json
@@ -37,7 +37,7 @@
     "priorityqueuejs": "1.0.0",
     "semaphore": "1.0.5",
     "underscore": "1.8.3",
-    "tunnel": "~0.0.5"
+    "tunnel": "0.0.5"
   },
   "repository": {
     "type": "git",

--- a/source/test/proxyTests.js
+++ b/source/test/proxyTests.js
@@ -1,0 +1,86 @@
+﻿/*
+ The MIT License (MIT)
+ Copyright (c) 2017 Microsoft Corporation
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+"use strict";
+
+process.env.HTTP_PROXY = "http://127.0.0.1:8989";
+
+var http = require("http"),
+    net = require("net"),
+    url = require("url"),
+    lib = require("../lib/"),
+    testConfig = require("./_testConfig");
+
+var Base = lib.Base,
+    DocumentDBClient = lib.DocumentClient;
+
+var proxy = http.createServer((req, resp) => {
+    resp.writeHead(200, { "Content-Type": "text/plain" });
+    resp.end();
+});
+
+proxy.on("connect", (req, clientSocket, head) => {
+    var serverUrl = url.parse(`http://${req.url}`);
+    var serverSocket = net.connect(serverUrl.port, serverUrl.hostname, () => {
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n" +
+            "Proxy-agent: Node.js-Proxy\r\n" +
+            "\r\n");
+        serverSocket.write(head);
+        serverSocket.pipe(clientSocket);
+        clientSocket.pipe(serverSocket);
+    });
+});
+
+var proxyPort = 8989;
+
+describe("Validate http proxy setting in environment variable", function () {
+    it("nativeApi Client Should successfully execute request", function (done) {
+        proxy.listen(proxyPort, "127.0.0.1", () => {
+            var client = new DocumentDBClient(testConfig.host, { masterKey: testConfig.masterKey });
+            // create database
+            client.createDatabase({ id: Base.generateGuidId() }, function (err, db) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+                proxy.close();
+            });
+        });
+    });
+
+    it("nativeApi Client Should execute request in error while the proxy setting is not correct", function (done) {
+        proxy.listen(proxyPort + 1, "127.0.0.1", () => {
+            var client = new DocumentDBClient(testConfig.host, { masterKey: testConfig.masterKey });
+            // create database
+            client.createDatabase({ id: Base.generateGuidId() }, function (err, db) {
+                if (!err) {
+                    done("Should create database in error while the proxy setting is not correct");
+                } else {
+                    done();
+                }
+                proxy.close();
+            });
+        });
+    });
+});


### PR DESCRIPTION
I'd like to add http/https proxy support for NodeJS SDK. 

The codes of PR is edited from PR https://github.com/Azure/azure-documentdb-node/pull/124.
As the PR https://github.com/Azure/azure-documentdb-node/pull/124 has not been merged for months, I raised this PR. 

@ryanmentzer , if you have time to continue your PR https://github.com/Azure/azure-documentdb-node/pull/124, please let me know, then I will close this PR. Otherwise I will try to merge this.